### PR TITLE
Make code compatible with latest ui-bootstrap

### DIFF
--- a/angular-prompt.js
+++ b/angular-prompt.js
@@ -1,6 +1,6 @@
 angular.module('cgPrompt',['ui.bootstrap']);
 
-angular.module('cgPrompt').factory('prompt',['$modal','$q',function($modal,$q){
+angular.module('cgPrompt').factory('prompt',['$uibModal','$q',function($uibModal,$q){
 
     var prompt = function(options){
 
@@ -29,7 +29,7 @@ angular.module('cgPrompt').factory('prompt',['$modal','$q',function($modal,$q){
 
         var defer = $q.defer();
 
-        $modal.open({
+        $uibModal.open({
             templateUrl:'angular-prompt.html',
             controller: 'cgPromptCtrl',
             resolve: {


### PR DESCRIPTION
ui-bootstrap changed it's API in version 0.14.0 cleaning it's name space
adding uib to prefix to each of it's services, this commit fixes the issue.